### PR TITLE
move 'outside-in' TDD para further up.

### DIFF
--- a/chapter_18.asciidoc
+++ b/chapter_18.asciidoc
@@ -2,8 +2,11 @@ Finishing "my lists": Outside-In TDD
 ------------------------------------
 
 In this chapter I'd like to talk about a technique called "outside-in" TDD.
-It's pretty much what we've been doing all along, but now I'll make it
-explicit, and talk about some of the common issues involved.
+It's pretty much what we've been doing all along. Our "double-loop" TDD
+process, in which we write the functional test first and then the unit tests,
+is already a manifestation of outside-in - we design the system from the
+outside, and build up our code in layers. Now I'll make it explicit, and talk
+about some of the common issues involved.
 
 What do we mean by "Outside-in"?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,12 +85,16 @@ some real-world usage. This is the natural order of things - your inner layers
 only exist to perform services for your outer layers, and should be subordinate
 to them in design and in purpose.
 
-
 The FT for "My Lists"
 ~~~~~~~~~~~~~~~~~~~~~
 
-Returning to our example, we know our `create_pre_authenticated_session` code
-works now, so we can just write our FT to look for a "My Lists" page:
+As we work through the following functional test, I'll point out how we start
+with the most outward-facing (presentation layer), through to the view
+functions (or "controllers"), and lastly the innermost layers, which in this
+case will be model code.
+
+We know our `create_pre_authenticated_session` code works now, so we can just
+write our FT to look for a "My Lists" page:
 
 
 [role="sourcecode"]
@@ -136,17 +143,6 @@ If you run it, the first error should look like this:
 selenium.common.exceptions.NoSuchElementException: Message: 'Unable to locate
 element: {"method":"link text","selector":"My lists"}' ; Stacktrace: 
 ----
-
-
-Outside-in TDD
-~~~~~~~~~~~~~~
-
-Our "double-loop" TDD process, in which we write the functional test first and
-then the unit tests, is already a manifestation of outside-in TDD - we design
-the system from the outside, and build up our code in layers. I'll point out
-how we start with the most outward-facing (presentation layer), through to the
-view functions (or "controllers"), and lastly the innermost layers, which in
-this case will be model code.
 
 
 The outside layer: presentation & templates


### PR DESCRIPTION
The text inserted by my previous commit made this later paragraph look
out of place. I've moved it up and split it so that the text now seems
to flow with continuity, rather than jumping back and forth between
topics.
