### PR TITLE
Click displayed button element on persona login

### DIFF
--- a/chapter_15.asciidoc
+++ b/chapter_15.asciidoc
@@ -595,7 +595,13 @@ class LoginTest(FunctionalTest):
         self.browser.find_element_by_id(
             'authentication_email'  #<2>
         ).send_keys('edith@mockmyid.com') #<3>
-        self.browser.find_element_by_tag_name('button').click()
+        displayed_button = [
+            b
+            for b
+            in self.browser.find_elements_by_tag_name('button')
+            if b.is_displayed()
+        ][0]
+        displayed_button.click()
 
         # The Persona window closes
         self.switch_to_new_window('To-Do')


### PR DESCRIPTION
Currently, personas login page considers desktop vs. mobile browsers.  This
results in several login button elements; but only displayed buttons are able
to be clicked by HTML/JavaScript.

(Sometimes the previous code would fail, another day it succeeds.)
