### PR TITLE
Tell the reader which html file this is

### DIFF
--- a/chapter_15.asciidoc
+++ b/chapter_15.asciidoc
@@ -130,8 +130,8 @@ Front-end Log in UI
 ^^^^^^^^^^^^^^^^^^^
 
 ((("spiking", "frontend")))
-Let's start with the front-end, just some log in and log out
-links...
+Let's start with the front-end, just some log in and log out links,
+in a new div near the start of 'lists/templates/base.html'.
 
 [role="sourcecode"]
 .lists/templates/base.html (ch15l001)


### PR DESCRIPTION
It took me a few moments of grepping back through
the book to figure out which html file this was
that we were editing.

This isn't needed if the filename in the markup surrounding
the source code somehow gets displayed as a caption for the
source code in the rendered book - but I don't see it in the
PDF version I'm looking at.
