### PR TITLE
Fix chapter's final summary box title

### DIFF
--- a/chapter_15.asciidoc
+++ b/chapter_15.asciidoc
@@ -26,12 +26,6 @@ fun called passwordless auth instead.
 module is ready and waiting for you. It's nice and straightforward, and I'll
 leave it to you to discover on your own.)
 
-((("authentication", "mocking", see="mocks/mocking")))
-((("mocks/mocking", "in JavaScript")))
-In this chapter, we're going to get pretty deep into a testing
-technique called "mocking". Personally, I know it took me a few weeks to
-really get my head around mocking, so don't worry if it's confusing at first.
-
 NOTE: This chapter has been substantially rewritten for the new edition, so
 let me know via obeythetestinggoat@gmail.com if you feel there's
 any particular sections where I don't explain things well, or where I'm 
@@ -1109,7 +1103,7 @@ external dependencies like email.
 
 
 
-.On Spiking and Mocking with JavaScript
+.User Authentication, Spiking and De-Spiking
 *******************************************************************************
 
 Spiking::


### PR DESCRIPTION
Also delete a paragraph about mocking, since all the
content on mocking has been move to the next chapter.
