### PR TITLE
ch12: fix subheading

### DIFF
--- a/chapter_12.asciidoc
+++ b/chapter_12.asciidoc
@@ -448,7 +448,7 @@ OK
 
 
 Some Integrity Errors Do Show Up on Save
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ((("model-layer validation", "integrity errors")))
 ((("integrity errors")))


### PR DESCRIPTION
This small issue prevented the subheading to render properly, see screenshot below:

<img width="495" alt="schermafbeelding 2016-09-03 om 10 31 13 am" src="https://cloud.githubusercontent.com/assets/659504/18223753/a4ccda16-71c1-11e6-9bc8-eebd09220f5a.png">

Thanks for the book, it's very nice!