### PR TITLE
Remove "TODO: add a failure message"

### DIFF
--- a/chapter_17.asciidoc
+++ b/chapter_17.asciidoc
@@ -1680,11 +1680,6 @@ def login(request):
 //45
 
 
-TODO: add a failure message?
-// optionally test it with  mocks, show how it couples us closely with the
-// implementation
-
-
 So are we there yet?
 
 


### PR DESCRIPTION
This is just a suggestion, obviously, ignore this PR if adding a failure
message is something you do fancy doing.

But, IMHO, adding a failure message isn't neccessary, because:

1. The idea that mocking closely couples to the implementation has already
   been demonstrated, with example tests, in the earlier sidebar "Mocks
   can leave you tightly coupled to the implementation"

2. The idea that the useability of this login system isn't perfectly
   polished is touched upon in the WARNING later in the text:

       "...in "real life" you’d want to explore a lot more security and
       usability issues before calling the job done."