### PR TITLE
Extend the rant against JSON fixtures

### DIFF
--- a/chapter_18.asciidoc
+++ b/chapter_18.asciidoc
@@ -281,8 +281,16 @@ using the `fixtures` class attribute on `TestCase`.
 
 More and more people are starting to say: 
 http://bit.ly/1kSTyrb[don't use JSON fixtures].
-They're a nightmare to maintain when your model changes.  Instead, if you can,
-load data directly using the Django ORM.
+They're a nightmare to maintain when your model changes.  Plus it's difficult
+for the reader to tell which of those many attribute values specified in the
+JSON are critical for the behaviour under test, and which are just filler.
+Finally, even if tests initially start sharing fixtures, sooner or later one
+test and then another will need to modify the data in the fixture, which means
+copying the fixture to avoid breaking the other tests.  These copies are
+verbose, and it's very difficult for the reader to tell which of the
+differences between each copy are critical to the test, versus just the
+happenstance of each copy's lineage. This all makes JSON fixtures
+unweildy to use. Instead, if you can, load data directly using the Django ORM.
 
 TIP: Once you have more than a few related models, even using the Django ORM
     can be cumbersome.  In this case, people recommend a tool called 


### PR DESCRIPTION
I extended the rant to include other reasons I dislike JSON fixtures.

You might consider the point - not to use them - already sufficiently made, so please ignore this PR if you wish.