### PR TITLE
Allow less secure apps

### DIFF
--- a/chapter_16.asciidoc
+++ b/chapter_16.asciidoc
@@ -304,9 +304,14 @@ EMAIL_USE_TLS = True
 
 TIP: If you want to use gmail as well, you'll probably have to visit your
     google account security settings page.  If you're using two-factor auth,
-    you'll want to set up an "app-specific password".  If you're not,
-    Google will reject SMTP requests until you configure your account
-    to "accept access for less secure apps".
+    you'll want to set up an
+    "link:https://myaccount.google.com/apppasswords[app-specific password]".
+    If you're not, Google will reject SMTP requests until you configure your
+    account to
+    "link:https://www.google.com/settings/security/lesssecureapps[accept access
+    for less secure apps]." If you're going to do that, you might want to
+    consider creating a new Google account for this purpose, rather than
+    using one containing any precious or sensitive data.
 
 
 Using environment variables to avoid secrets in source code

--- a/chapter_16.asciidoc
+++ b/chapter_16.asciidoc
@@ -304,9 +304,9 @@ EMAIL_USE_TLS = True
 
 TIP: If you want to use gmail as well, you'll probably have to visit your
     google account security settings page.  If you're using two-factor auth,
-    you'll want to set up an "app-specific password".  Even if you're not,
-    Google might reject SMTP requests it doesn't recognise, until you mark
-    them as authorised.
+    you'll want to set up an "app-specific password".  If you're not,
+    Google will reject SMTP requests until you configure your account
+    to "accept access for less secure apps".
 
 
 Using environment variables to avoid secrets in source code

--- a/chapter_17.asciidoc
+++ b/chapter_17.asciidoc
@@ -1840,7 +1840,7 @@ ConnectionRefusedError: [Errno 111] Connection refused
 
 
 You'll probably get an error, like I did, when you try to run things manually.
-Two possible problems:
+Three possible problems:
 
 * Firstly, we need to re-add the email configuration to settings.py
 * Secondly, we probably need to `export` the email password in our shell.
@@ -1863,6 +1863,14 @@ and
 $ pass:quotes[*export EMAIL_PASSWORD="sekrit"*]
 $ pass:quotes[*python manage.py runserver*]
 ----
+
+* Thirdly, on entering your email to log in, you might get a SMTPSenderRefused
+  error, if you're using a GMail account to send emails but you didn't follow
+  the earlier chapter's advice on configuring your Google account to allow
+  this, either using an app-specific password, or by allowing access by less
+  secure apps.
+
+But if all goes well...
 
 
 [[despiked-success-message]]


### PR DESCRIPTION
As I understand it: The book's current advice to create app-specific passwords in your Google account is only correct if your Google account uses 2-factor authentication.

This PR advises readers of what to do if they don't use 2-factor. In this case, creating app-specific passwords is not possible, and SMTP requests are refused unless you configure your google account to "allow access for less secure apps"
