### PR TITLE
Fix markup of __init__.py

### DIFF
--- a/chapter_06.asciidoc
+++ b/chapter_06.asciidoc
@@ -52,8 +52,8 @@ out.
 'manage.py'. As of Django 1.6, the test runner will find any files whose name
 begins with 'test'.  To keep things neat and tidy, let's make a folder for
 our functional tests, so that it looks a bit like an app. All Django needs is
-for it to be a valid Python package directory (i.e., one with a '\___init___.py'
-in it):
+for it to be a valid Python package directory (i.e., one with a 
++++<i>___init___.py</i>+++ in it):
 
 [subs=""]
 ----

--- a/chapter_06.asciidoc
+++ b/chapter_06.asciidoc
@@ -52,7 +52,7 @@ out.
 'manage.py'. As of Django 1.6, the test runner will find any files whose name
 begins with 'test'.  To keep things neat and tidy, let's make a folder for
 our functional tests, so that it looks a bit like an app. All Django needs is
-for it to be a valid Python package directory (i.e., one with a '\_\_init__.py'
+for it to be a valid Python package directory (i.e., one with a '\___init___.py'
 in it):
 
 [subs=""]


### PR DESCRIPTION
This was rendered in HTML as

    _\_init__.py

This commit makes it render as

    __init__.py (in italics)

which I think is desired.