### PR TITLE
Fix typo: remove extra 'c' in 'acccounts'

### DIFF
--- a/chapter_mocking.asciidoc
+++ b/chapter_mocking.asciidoc
@@ -192,7 +192,7 @@ we're just taking advantage of Python's dynamic nature and scoping rules.
 
 Up until we actually invoke a function, we can modify the variables it has
 access to, as long as we get into the right namespace (that's why we import the
-top-level accounts module, to be able to get down to the `acccounts.views` module,
+top-level accounts module, to be able to get down to the `accounts.views` module,
 which is the scope that the `accounts.views.send_login_email` function will run
 in).
 


### PR DESCRIPTION
This corrects a small typo in the mocking chapter: there was an extra 'c' in 'accounts'. (Hope this pull request is okay; it's my first. Thanks for writing a great book, btw.)