### PR TITLE
Fixed typo in systemctl

### DIFF
--- a/chapter_server_side_debugging.asciidoc
+++ b/chapter_server_side_debugging.asciidoc
@@ -154,7 +154,7 @@ the server with a:
 [subs="specialcharacters,quotes"]
 ----
 elspeth@server:$ *sudo systemctl daemon-reload*
-elspeth@server:$ *sudo systemctrl restart gunicorn-superlists-staging.ottg.eu*
+elspeth@server:$ *sudo systemctl restart gunicorn-superlists-staging.ottg.eu*
 elspeth@server:$ *tail -f error.log*  # assumes we are in ~/sites/$SITENAME folder
 ----
 


### PR DESCRIPTION
systemctl was misspelled  as systemctrl after enabling debugging in gunicorn