### PR TITLE
Corrected number of lines replaced with assertIn

### DIFF
--- a/chapter_post_and_database.asciidoc
+++ b/chapter_post_and_database.asciidoc
@@ -419,7 +419,7 @@ Buy peacock feathers
 You know what could be even better than that?  Making that assertion a bit less
 clever.  As you may remember, I was very pleased with myself for using the
 `any` function, but one of my Early Release readers (thanks Jason!) suggested
-a much simpler implementation.  We can replace all six lines of the
+a much simpler implementation.  We can replace all four lines of the
 `assertTrue` with a single `assertIn`:
 
 [role="sourcecode"]


### PR DESCRIPTION
In the older text (which didn't make use of the new "f-string" syntax), the assertTrue(...) for the first list item took up six lines. The new notation reduced this to four, and using the assertIn(...) test further reduced it to one.