### PR TITLE
Grammatical fix, changing 'so' to 'but'

### DIFF
--- a/chapter_explicit_waits_1.asciidoc
+++ b/chapter_explicit_waits_1.asciidoc
@@ -263,7 +263,7 @@ To run the unit tests::
 What to do if I say "run the tests", and you're not sure which ones I mean?
 Have another look at the flowchart at the end of <<chapter_philosophy_and_refactoring>>, and try and
 figure out where we are.  As a rule of thumb, we usually only run the
-functional tests once all the unit tests are passing, so if in doubt, try both!
+functional tests once all the unit tests are passing, but if in doubt, try both!
 
 *******************************************************************************
 


### PR DESCRIPTION
The first two parts  of the sentence suggest the most probable action to be taken, whereas the last part suggests an alternative. In this situation I feel that 'but' would be a more appropriate conjunction