### PR TITLE
Use from django.urls import resolve

### DIFF
--- a/chapter_unit_test_first_view.asciidoc
+++ b/chapter_unit_test_first_view.asciidoc
@@ -272,7 +272,7 @@ test to something like this:
 .lists/tests.py
 [source,python]
 ----
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.test import TestCase
 from lists.views import home_page  #<2>
 
@@ -577,7 +577,7 @@ with HTML to the browser. Open up 'lists/tests.py', and add a new
 .lists/tests.py
 [source,python]
 ----
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.test import TestCase
 from django.http import HttpRequest
 


### PR DESCRIPTION
As of Django 1.10.0 django.core.urlresolvers.resolve has been replaced
with django.urls.resolve.

See https://docs.djangoproject.com/en/1.11/ref/urlresolvers/