### PR TITLE
update chapter number scopes of book parts

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -162,19 +162,19 @@ Outline
 
 I've split this book into three parts.
 
-pass:[<xref linkend="part1" xrefstyle="chap-num-title"/>] (Chapters 1–6): The basics::
+pass:[<xref linkend="part1" xrefstyle="chap-num-title"/>] (Chapters 1–7): The basics::
     Dives straight into building a simple web app using TDD. We start by
     writing a functional test (with Selenium), then we go through the basics of
     Django--models, views, templates--with rigorous unit testing at every
     stage. I also introduce the Testing Goat.
 
-pass:[<xref linkend="part2" xrefstyle="chap-num-title"/>] (Chapters 7–14): Web development essentials:: 
+pass:[<xref linkend="part2" xrefstyle="chap-num-title"/>] (Chapters 8–17): Web development essentials:: 
     Covers some of the trickier but unavoidable aspects of web development, and
     shows how testing can help us with them: static files, deployment to
     production, form data validation, database migrations, and the dreaded
     JavaScript.
 
-pass:[<xref linkend="part3" xrefstyle="chap-num-title"/>] (Chapters 15–20): More advanced topics::
+pass:[<xref linkend="part3" xrefstyle="chap-num-title"/>] (Chapters 18–27): More advanced topics::
     Mocking, integrating a third-party authentication system, Ajax, test
     fixtures, Outside-In TDD, and Continuous Integration (CI).
 


### PR DESCRIPTION
update chapter number scopes of book parts to match the current state as of bab0b9b6993a14f82efecb38f7bc4804f986b2c3

(I've also counted the [Epilogue](http://www.obeythetestinggoat.com/book/epilogue.html), as that is a numbered chapter in the TOC. I didn't count the appendices although the TOC makes it seem as if they blong to part 3, too.)

You might want to check whether the content descriptions of the parts still matches, too. (I've just started reading the book, so I can't know.)