### PR TITLE
Fixes typo

### DIFF
--- a/server-quickstart.md
+++ b/server-quickstart.md
@@ -121,7 +121,7 @@ all over your domain until you configure it.
 
 Once you have a domain, you need to set up a couple of **A-records** in
 its DNS configration, one for your "staging" subdomain and one for your
-"live" subdomain.  Mine are superlists.ottg.eu and superlists.ottg.eu
+"live" subdomain.  Mine are superlists.ottg.eu and superlists-staging.ottg.eu
 for example.
 
 *(tip: DNS changes take time to propagate, so if your domain doesn't

--- a/server-quickstart.md
+++ b/server-quickstart.md
@@ -121,7 +121,7 @@ all over your domain until you configure it.
 
 Once you have a domain, you need to set up a couple of **A-records** in
 its DNS configration, one for your "staging" subdomain and one for your
-"live" subdomain.  Mine are superlists.ottg.eu and superlists-staging.ottg.eu
+"live" subdomain.  Mine are *superlists.ottg.eu* and *superlists-staging.ottg.eu*
 for example.
 
 *(tip: DNS changes take time to propagate, so if your domain doesn't


### PR DESCRIPTION
Changes one of the example subdomains to actually be superlists-staging.ottg.eu