### PR TITLE
Update chapter_simple_form.asciidoc (small typo)

### DIFF
--- a/chapter_simple_form.asciidoc
+++ b/chapter_simple_form.asciidoc
@@ -554,7 +554,7 @@ class FunctionalTest(StaticLiveServerTestCase):
 ====
 
 And then we use it throughout--I had to make four changes in 
-'test_simple_list_creation.py', two in 'test_layout_and_styling.py', and four
+'test_simple_list_creation.py', two in 'test_layout_and_styling.py', and six
 in 'test_list_item_validation.py', for example:
 
 


### PR DESCRIPTION
Small typo regarding stated number of changes needing to be made vs. actual number of changes to be made in superlists/functional_tests/test_list_item_validation.py

`browser.find_element_by_id('id_new_item')`--> `get_item_input_box()`

see:
https://github.com/hjwp/book-example/blob/860776cd9ed48891e718666acbce0fb97408adbc/functional_tests/test_list_item_validation.py 
vs 
https://github.com/hjwp/book-example/blob/8f656effc2cca885cd1b71db2a7f53272774c1d9/functional_tests/test_list_item_validation.py