### PR TITLE
Minor typo causes unit test to fail

### DIFF
--- a/chapter_philosophy_and_refactoring.asciidoc
+++ b/chapter_philosophy_and_refactoring.asciidoc
@@ -359,7 +359,7 @@ https://docs.djangoproject.com/en/1.11/intro/tutorial03/#write-views-that-actual
 [source,html]
 ----
 <html>
-    <title>To-Do lists</title>
+    <title>To-Do Lists</title>
 </html>
 ----
 ====


### PR DESCRIPTION
The test "test_page_returns_correct_html" (prior to being refactored) expects the title element to be "To-Do Lists", but the template file has "lists" as all lower case. Correcting the home.html file allows the test to pass