### PR TITLE
Missing word in the overview

### DIFF
--- a/chapter_manual_deployment.asciidoc
+++ b/chapter_manual_deployment.asciidoc
@@ -154,7 +154,7 @@ keep your bearings:
   configure efficient static file serving, set our app to start automatically
   on boot with Systemd.
 
-* Security: Use environment variables to +DEBUG+ to +False+, change the
+* Security: Use environment variables to set +DEBUG+ to +False+, change the
   +SECRET_KEY+, and so on
 
 


### PR DESCRIPTION
There is a word missing in the overview for the chapter on "moving to a production-ready config", specifically between "to" and "DEBUG"  in the Security bullet-point. "set" seems like a good fit.