### PR TITLE
Update chapter_mocking.asciidoc

### DIFF
--- a/chapter_mocking.asciidoc
+++ b/chapter_mocking.asciidoc
@@ -767,8 +767,8 @@ class LoginViewTest(TestCase):
 We're imagining we'll pass the token in as a GET parameter, after the `?`.
 It doesn't need to do anything for now.
 
-I'm sure you can find your way through to getting the boilerplate for a basic
-URL and view in, via errors like these:
+I'm sure you can find your way through to writing the boilerplate for a basic
+URL and view, via errors like these:
 
 [role="pagebreak-before"]
 * No URL:

--- a/chapter_mocking.asciidoc
+++ b/chapter_mocking.asciidoc
@@ -767,7 +767,7 @@ class LoginViewTest(TestCase):
 We're imagining we'll pass the token in as a GET parameter, after the `?`.
 It doesn't need to do anything for now.
 
-I'm sure you can find your way through to writing the boilerplate for a basic
+I'm sure you can find your way through to getting the boilerplate in for a basic
 URL and view, via errors like these:
 
 [role="pagebreak-before"]


### PR DESCRIPTION
The original phrasing (..getting the boilerplate for a basic URL and view in, via...) makes it look like a word is missing.