### PR TITLE
Unnecessary 'as'

### DIFF
--- a/chapter_purist_unit_tests.asciidoc
+++ b/chapter_purist_unit_tests.asciidoc
@@ -620,7 +620,7 @@ another of the view's collaborators, the `redirect` function:
 <1> We mock out the `redirect` function, this time at the method level.
 
 <2> `patch` decorators are applied innermost first, so the new mock is injected
-    to our method as before the `mockNewListForm`.
+    to our method before the `mockNewListForm`.
 
 <3> We specify that we're testing the case where the form is valid.
 


### PR DESCRIPTION
The word 'as' does not belong in the sentence "patch decorators are applied innermost first, so the new mock is injected to our method **as** before the mockNewListForm"