### PR TITLE
typo + missing a "]" in a footnote

### DIFF
--- a/chapter_making_deployment_production_ready.asciidoc
+++ b/chapter_making_deployment_production_ready.asciidoc
@@ -415,8 +415,8 @@ OK
 ----
 
 Hooray, a change that went without a hitch for once!footnote:[If you're using
-Fedora/CentOS, you may run into an issue with private _tmmp_ directories.
-https://github.com/hjwp/Book-TDD-Web-Dev-Python/issues/93[more info here]
+Fedora/CentOS, you may run into an issue with private _tmp_ directories.
+https://github.com/hjwp/Book-TDD-Web-Dev-Python/issues/93[more info here]]
 Moving on...
 
 


### PR DESCRIPTION
The footnote in chapter 10 is not rendered correctly ;)

> Hooray, a change that went without a hitch for once!footnote:[If you’re using Fedora/CentOS, you may run into an issue with private tmmp directories. more info here Moving on…​

Thanks again for the great book!