### PR TITLE
superlists/superlists

### DIFF
--- a/chapter_unit_test_first_view.asciidoc
+++ b/chapter_unit_test_first_view.asciidoc
@@ -435,7 +435,7 @@ urls.py
 ((("URL mappings")))Our
 tests are telling us that we need a URL mapping. Django uses a file called
 'urls.py' to map URLs to view functions. There's a main 'urls.py' for the whole
-site in the 'superlists/superlists' folder. Let's go take a look:
+site in the 'superlists' folder. Let's go take a look:
 
 
 [role="sourcecode currentcontents"]


### PR DESCRIPTION
I think this mention of superlists/superlists is a holdover from v1 of the book. There shouldn't be a superlists/superlists in v2 because `$ django-admin.py startproject superlists .` was used for starting the project in chapter 1.