### PR TITLE
Suggested edits to Chapter 3 (unit testing) to be explicit about a change to source

### DIFF
--- a/chapter_post_and_database.asciidoc
+++ b/chapter_post_and_database.asciidoc
@@ -1545,7 +1545,8 @@ worse:
 
 Grrr.  We're so close! We're going to need some kind of automated way of
 tidying up after ourselves. For now, if you feel like it, you can do it
-manually, by deleting the database and re-creating it fresh with `migrate`:
+manually, by deleting the database and re-creating it fresh with `migrate`
+(you'll need to shut down your Django server first):
 
 [subs="specialcharacters,quotes"]
 ----
@@ -1553,7 +1554,8 @@ $ *rm db.sqlite3*
 $ *python manage.py migrate --noinput*
 ----
 
-And then reassure yourself that the FT still passes.
+And then (after restarting your server!) reassure yourself that the FT still 
+passes.
 
 Apart from that little bug in our functional testing, we've got some code
 that's more or less working.  Let's do a commit.((("", startref="DTproduction05")))  

--- a/chapter_unit_test_first_view.asciidoc
+++ b/chapter_unit_test_first_view.asciidoc
@@ -600,7 +600,7 @@ with HTML to the browser. Open up 'lists/tests.py', and add a new
 ----
 from django.urls import resolve
 from django.test import TestCase
-from django.http import HttpRequest
+from django.http import HttpRequest #<1>
 
 from lists.views import home_page
 
@@ -624,12 +624,13 @@ class HomePageTest(TestCase):
 
 What's going on in this new test?  
 
-<1> We create an `HttpRequest` object, which is what Django will see when
-    a user's browser asks for a page.
+<1> We import the `HttpRequest` class so that we can then create an 
+    `HttpRequest` object within our test. When a user's browser asks for a
+    page, Django will see that object.
 
-<2> We pass it to our `home_page` view, which gives us a response. You won't be
-    surprised to hear that this object is an instance of a class called
-    `HttpResponse`.
+<2> We pass the `HttpRequest` object to our `home_page` view, which gives us a 
+    response. You won't be surprised to hear that the response is an instance 
+    of a class called `HttpResponse`.
 
 <3> Then, we extract the `.content` of the response.  These are the raw bytes,
     the ones and zeros that would be sent down the wire to the user's browser.


### PR DESCRIPTION
These edits are intended to add explicit discussions of `import` statements that are changed in the code samples in the book but that are not (now) explicitly called to the reader's attention.

## First commit re: urls.py

The proposed edits clarify something that confused me as I was working through the book. In the discussion of editing `superlists/urls.py`, there is no explicit mention of changing the `import` statements. In particular, there's no comment in the text about adding the statement `from lists import views`. Without that statement, the tests fail with messages other than those discussed in the book. 

I think I'm like most readers: I assumed that the changes to the source code would be flagged by the writer. Since the only flagged change was to the regular expression for the URL pattern, I didn't think to check whether I needed to change the `import` statements. The proposed edits would avoid this confusion for readers like me.

## Second commit re: tests.py

In Example 8, the code includes a new import statement (`from django.http import HttpRequest`), but the text and notes don't mention this statement. I think it should be mentioned explicitly in connection with note 1, which describes the use of `HttpRequest()` within the test itself. I did my best to use the word "object" properly based on how it was used in the existing text. 

## Notes

I am not expert with the ASCIIdoc format used in the source. It looks like the lines are wrapped manually, so I inserted hard returns to break lines at what seemed to be the appropriate length based on the rest of the source. Using hard returns this way in body copy strikes me as insane, but it seemed to be what was expected, so I did it.

Also, I think I did an unnecessary pull/merge in my fork, so I apologize if the commits are confusing. I am just proposing changes to two areas in the text.