### PR TITLE
user can disregard droplet options

### DIFF
--- a/server-quickstart.md
+++ b/server-quickstart.md
@@ -46,7 +46,9 @@ and [here](https://www.digitalocean.com/community/tutorials/how-to-use-ssh-keys-
 ## Start a Droplet
 
 A "droplet" is Digital Ocean's name for a server.  Pick the default Ubuntu,
-the cheapest type, and whichever region is closest to you.
+the cheapest type, and whichever region is closest to you. You won't need
+access to the ancillary services that are available (Block storage, a VPC
+network, IPv6, User-Data, Monitoring or Back-Ups)
 
 * Choose **New SSH Key** and upload your public key from above
 


### PR DESCRIPTION
Digital ocean droplets have options for configuring block storage, a VPC network, IPv6, user-data, monitoring and back-ups when creating a droplet. These can be ignored (hopefully! I've just ignored them and I've never setup a web server before)