### PR TITLE
Replace django-admin.py with django-admin

### DIFF
--- a/chapter_01.asciidoc
+++ b/chapter_01.asciidoc
@@ -151,7 +151,7 @@ Django provides a little command-line tool for this:
 
 [subs="specialcharacters,quotes"]
 ----
-$ *django-admin.py startproject superlists .*
+$ *django-admin startproject superlists .*
 ----
 
 Don't forget that "." at the end; it's important!


### PR DESCRIPTION
Running on Django v1.11.25 ...
```
django-admin.py startproject superlists .
```
... opens the file `django-admin.py`

Whereas running ...
```
django-admin startproject superlists . 
```
... runs as expected generating a new project called superlists

---

As someone who's just starting a new job on a Django system, I'm extremely grateful that this book exists. I'm finding it extremely useful, and am really enjoying reading it (I read ahead without coding along - a grave mistake!) in spite of the fact that its a technical book.  Thanks a lot Harry for dedicating a vast amount of time towards writing this!  