### PR TITLE
authenticate method now requires request parameter

### DIFF
--- a/chapter_spiking_custom_auth.asciidoc
+++ b/chapter_spiking_custom_auth.asciidoc
@@ -491,7 +491,7 @@ from django.shortcuts import redirect, render
 def login(request):
     print('login view', file=sys.stderr)
     uid = request.GET.get('uid')
-    user = authenticate(uid=uid)
+    user = authenticate(request, uid=uid)
     if user is not None:
         auth_login(request, user)
     return redirect('/')
@@ -518,7 +518,7 @@ from accounts.models import ListUser, Token
 
 class PasswordlessAuthenticationBackend(object):
 
-    def authenticate(self, uid):
+    def authenticate(self, request, uid=None):
         print('uid', uid, file=sys.stderr)
         if not Token.objects.filter(uid=uid).exists():
             print('no token found', file=sys.stderr)


### PR DESCRIPTION
As far back as Django 1.11, it is necessary to pass the request object to the authenticate method otherwise the method does not match the signature of the parent and does not get called. For reference: https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#writing-an-authentication-backend

This remains true for Django 4.2