### PR TITLE
authenticate method now requires request parameter 

### DIFF
--- a/chapter_spiking_custom_auth.asciidoc
+++ b/chapter_spiking_custom_auth.asciidoc
@@ -491,7 +491,7 @@ from django.shortcuts import redirect, render
 def login(request):
     print('login view', file=sys.stderr)
     uid = request.GET.get('uid')
-    user = authenticate(request, uid=uid)
+    user = authenticate(uid=uid)
     if user is not None:
         auth_login(request, user)
     return redirect('/')
@@ -516,9 +516,9 @@ separation of concerns:
 import sys
 from accounts.models import ListUser, Token
 
-class PasswordlessAuthenticationBackend(object):
+class PasswordlessAuthenticationBackend:
 
-    def authenticate(self, request, uid=None):
+    def authenticate(self, request=None, uid=None):
         print('uid', uid, file=sys.stderr)
         if not Token.objects.filter(uid=uid).exists():
             print('no token found', file=sys.stderr)

--- a/chapter_spiking_custom_auth.asciidoc
+++ b/chapter_spiking_custom_auth.asciidoc
@@ -491,7 +491,7 @@ from django.shortcuts import redirect, render
 def login(request):
     print('login view', file=sys.stderr)
     uid = request.GET.get('uid')
-    user = authenticate(uid=uid)
+    user = authenticate(request, uid=uid)
     if user is not None:
         auth_login(request, user)
     return redirect('/')
@@ -518,7 +518,7 @@ from accounts.models import ListUser, Token
 
 class PasswordlessAuthenticationBackend(object):
 
-    def authenticate(self, uid):
+    def authenticate(self, request, uid=None):
         print('uid', uid, file=sys.stderr)
         if not Token.objects.filter(uid=uid).exists():
             print('no token found', file=sys.stderr)


### PR DESCRIPTION
As of Django 2.1, it is necessary to have the request object in the authenticate method signature otherwise the method does not  get called. For reference: https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#writing-an-authentication-backend

This remains true for Django 4.2