### PR TITLE
Update logout view

### DIFF
--- a/chapter_mocking.asciidoc
+++ b/chapter_mocking.asciidoc
@@ -2148,13 +2148,13 @@ session and redirects them to a page of our choice:
 ====
 [source,python]
 ----
-from django.contrib.auth.views import logout
+from django.contrib.auth.views import logout_then_login as logout
 [...]
 
 urlpatterns = [
     url(r'^send_login_email$', views.send_login_email, name='send_login_email'),
     url(r'^login$', views.login, name='login'),
-    url(r'^logout$', logout, {'next_page': '/'}, name='logout'),
+    url(r'^logout$', logout, {'login_url': '/'}, name='logout'),
 ]
 ----
 ====


### PR DESCRIPTION
django.contrib.auth.views.logout seems to have been replaced by  django.contrib.auth.views.logout_then_login, which has a different parameter name (login_url instead of next_page). I'm not sure when this change was made