### PR TITLE
Fix usage of deprecated Selenium APIs on Ch12

### DIFF
--- a/chapter_organising_test_files.asciidoc
+++ b/chapter_organising_test_files.asciidoc
@@ -397,7 +397,7 @@ def test_cannot_add_empty_list_items(self):
     # The home page refreshes, and there is an error message saying
     # that list items cannot be blank
     self.assertEqual(
-        self.browser.find_element(By.CSS_SELECTOR, '.has-error').text, #<1>
+        self.browser.find_element(By.CSS_SELECTOR, '.has-error').text,  #<1>
         "You can't have an empty list item"  #<2>
     )
 

--- a/chapter_organising_test_files.asciidoc
+++ b/chapter_organising_test_files.asciidoc
@@ -397,7 +397,7 @@ def test_cannot_add_empty_list_items(self):
     # The home page refreshes, and there is an error message saying
     # that list items cannot be blank
     self.assertEqual(
-        self.browser.find_element_by_css_selector('.has-error').text,  #<1>
+        self.browser.find_element(By.CSS_SELECTOR, '.has-error').text, #<1>
         "You can't have an empty list item"  #<2>
     )
 
@@ -441,7 +441,7 @@ until this assertion passes".  Something like this:
     # The home page refreshes, and there is an error message saying
     # that list items cannot be blank
     self.wait_for(lambda: self.assertEqual(  #<1>
-        self.browser.find_element_by_css_selector('.has-error').text,
+        self.browser.find_element(By.CSS_SELECTOR, '.has-error').text,
         "You can't have an empty list item"
     ))
 ----
@@ -575,7 +575,7 @@ Traceback (most recent call last):
     return fn()  <2>
   File "...goat-book/functional_tests/test_list_item_validation.py", line
 16, in <lambda>  <3>
-    self.browser.find_element_by_css_selector('.has-error').text,  <3>
+    self.browser.find_element(By.CSS_SELECTOR, '.has-error').text, <3>
 [...]
 selenium.common.exceptions.NoSuchElementException: Message: Unable to locate
 element: .has-error
@@ -626,7 +626,7 @@ We'll finish off the FT like this:
     # The home page refreshes, and there is an error message saying
     # that list items cannot be blank
     self.wait_for(lambda: self.assertEqual(
-        self.browser.find_element_by_css_selector('.has-error').text,
+        self.browser.find_element(By.CSS_SELECTOR, '.has-error').text,
         "You can't have an empty list item"
     ))
 
@@ -640,7 +640,7 @@ We'll finish off the FT like this:
 
     # She receives a similar warning on the list page
     self.wait_for(lambda: self.assertEqual(
-        self.browser.find_element_by_css_selector('.has-error').text,
+        self.browser.find_element(By.CSS_SELECTOR, '.has-error').text,
         "You can't have an empty list item"
     ))
 

--- a/chapter_organising_test_files.asciidoc
+++ b/chapter_organising_test_files.asciidoc
@@ -575,7 +575,7 @@ Traceback (most recent call last):
     return fn()  <2>
   File "...goat-book/functional_tests/test_list_item_validation.py", line
 16, in <lambda>  <3>
-    self.browser.find_element(By.CSS_SELECTOR, '.has-error').text, <3>
+    self.browser.find_element(By.CSS_SELECTOR, '.has-error').text,  <3>
 [...]
 selenium.common.exceptions.NoSuchElementException: Message: Unable to locate
 element: .has-error


### PR DESCRIPTION
Selenium's `find_element_by_*` methods have been deprecated, in favor of `find_element`.