### PR TITLE
fix: chapter 2 typos

### DIFF
--- a/chapter_02_unittest.asciidoc
+++ b/chapter_02_unittest.asciidoc
@@ -118,7 +118,7 @@ I learned in school that comments are good practice?
 
 They were exaggerating for effect.
 There is definitely a place for comments that add context and intention.
-But my colleagues were pointing that comments aren't always as useful as you hope.
+But my colleagues were pointing out that comments aren't always as useful as you hope.
 For starters, it's pointless to write a comment that just repeats what you're doing with the code:
 
 [role="skipme"]
@@ -153,7 +153,7 @@ Check out this video by the great Dave Farley if you want a taste:
 https://youtu.be/JDD5EEJgpHU?t=272
 ].
 
-For more on comments, I recommend John Ousterhoudt's _A Philosohpy of Software Design_,
+For more on comments, I recommend John Ousterhoudt's _A Philosophy of Software Design_,
 which you can get a taste of by reading
 his https://web.stanford.edu/~ouster/cgi-bin/cs190-spring16/lecture.php?topic=comments[lecture notes from the chapter on comments.]
 *******************************************************************************


### PR DESCRIPTION
1) adds a missing 'out' 
2) correct 'Philosohpy' to 'Philosophy' 