### PR TITLE
Corrected grammatical error. an src -> a src

### DIFF
--- a/chapter_09_docker.asciidoc
+++ b/chapter_09_docker.asciidoc
@@ -459,7 +459,7 @@ TIP: Don't use `export` to set the 'TEST_SERVER' environment variable;
     Setting it explicitly inline each time you run the FTs is best.
 
 
-==== Making an src Folder
+==== Making a src Folder
 
 // DAVID: FWIW it reads weirdly to me to have 'an src' rather than 'a src'.
 // It's probably because I pronounce it as 'source' rather than 'S.R.C.'


### PR DESCRIPTION
A small grammatical error I noticed. Love the book! 