### PR TITLE
Fix a listing in 14

### DIFF
--- a/chapter_14_simple_form.asciidoc
+++ b/chapter_14_simple_form.asciidoc
@@ -653,25 +653,28 @@ OK
 And the functional tests too, where we can see three errors:
 
 ----
-ERROR: test_layout_and_styling (functional_tests.test_layout_and_styling.LayoutAndStylingTest.test_layout_and_styling)
+ERROR: test_layout_and_styling (functional_tests.test_layout_and_styling.Layout
+AndStylingTest.test_layout_and_styling)
 [...]
 selenium.common.exceptions.NoSuchElementException: Message: Unable to locate
-element: [id="id_text"];
+element: [id="id_text"]; [...]
 [...]
-ERROR: test_can_start_a_todo_list (functional_tests.test_simple_list_creation.NewVisitorTest.test_can_start_a_todo_list)
+ERROR: test_can_start_a_todo_list (functional_tests.test_simple_list_creation.N
+ewVisitorTest.test_can_start_a_todo_list)
 [...]
 selenium.common.exceptions.NoSuchElementException: Message: Unable to locate
-element: [id="id_text"];
+element: [id="id_text"]; [...]
 [...]
 ----
 
 and
 
 ----
-ERROR: test_cannot_add_empty_list_items (functional_tests.test_list_item_validation.ItemValidationTest.test_cannot_add_empty_list_items)
+ERROR: test_cannot_add_empty_list_items (functional_tests.test_list_item_valida
+tion.ItemValidationTest.test_cannot_add_empty_list_items)
 [...]
 selenium.common.exceptions.NoSuchElementException: Message: Unable to locate
-element: .invalid-feedback;
+element: .invalid-feedback; [...]
 [...]
 ----
 


### PR DESCRIPTION
hopefully will get the tests passing.

* the failure was due to the fact that the test runner wraps console output at 80 chars.
* that hid a second failure, which is that when we report `NoSuchElementException`, selenium prints a whole load of carp, that we basically have to hide in the output listings with a trailing `[...]` on the line.
