### PR TITLE
Update chapter_12_organising_test_files.asciidoc: fix link

### DIFF
--- a/chapter_12_organising_test_files.asciidoc
+++ b/chapter_12_organising_test_files.asciidoc
@@ -264,7 +264,7 @@ class FunctionalTest(StaticLiveServerTestCase):
 
 NOTE: Keeping helper methods in a base `FunctionalTest` class
     is one useful way of preventing duplication in FTs.
-    Later in the book (in <<chapter_page_pattern>>) we'll use the "Page pattern",
+    Later in the book (in xref:chapter_page_pattern.asciidoc[The Token Social Bit, the Page Pattern, and an Exercise for the Reader]) we'll use the "Page pattern",
 // CSANAD: is this reference to the chapter "The Token Social Bit, the Page
 //         Pattern, and an Exercise for the Reader" as chapter_page_pattern
 // still clear in print?


### PR DESCRIPTION
Fix link to the chapter The Token Social Bit, the Page Pattern, and an Exercise for the Reader.

The link was broken when reading directly on GitHub.