### PR TITLE
Csanád address ch 13 review comments

### DIFF
--- a/chapter_13_database_layer_validation.asciidoc
+++ b/chapter_13_database_layer_validation.asciidoc
@@ -147,7 +147,8 @@ Which means, since TextField is a type of Field, it _should_ disallow empty valu
 ((("data integrity errors")))
 So why is the test still failing?
 Well, for
-http://bit.ly/2v3SfRq[slightly counterintuitive historical reasons],
+https://groups.google.com/g/django-developers/c/uIhzSwWHj4c[slightly
+counterintuitive historical reasons],
 Django models don't run full validation on save.
 As we'll see later,
 any constraints that are actually implemented in the database will raise errors on save,


### PR DESCRIPTION
TODO:

- [x]  "Well, for
http://bit.ly/2v3SfRq[slightly counterintuitive historical reasons],
Django models don't run full validation on save.
// CSANAD: I'd argue against the use of shortened URLs."
=> https://groups.google.com/g/django-developers/c/uIhzSwWHj4c ? 
Check URL first

