### PR TITLE
Csanad: review chapter 17

### DIFF
--- a/chapter_17_second_deploy.asciidoc
+++ b/chapter_17_second_deploy.asciidoc
@@ -183,6 +183,9 @@ $ *export TAG=`date +DEPLOYED-%F/%H%M`*
 $ *git tag $TAG*
 $ *git push -f origin LIVE $TAG*
 ----
+// CSANAD: at the time of writing this comment, the `git tag LIVE` in chapter 11
+// has been commented out so the -f and the explanation "# needs the -f because
+// we are replacing the old tag" is not true.
 
 NOTE: Some people don't like to use `push -f` and update an existing tag,
     and will instead use some kind of version number to tag their releases.

--- a/chapter_17_second_deploy.asciidoc
+++ b/chapter_17_second_deploy.asciidoc
@@ -94,6 +94,25 @@ And run the tests against staging:
 $ pass:quotes[*TEST_SERVER=staging.ottg.co.uk python src/manage.py test functional_tests*]
 OK
 ----
+// CSANAD: I needed to add `force_source` to the "Import container image on
+//         server" task. Otherwise, the server would deploy a container based on
+// the old image, even though a new one was successfully created locally (and
+// copied as well).
+// We changed quite a few things in the source since the last deployment. The
+// first error showing up from running the FTs would be a failure to find
+// `id_text`. And indeed, if we open the page and inspect the input box
+// manually, we can see that it still has its old name, `id_new_item`.
+//
+// So the Ansible task with the working setup is:
+//
+//     - name: Import container image on server
+//       community.docker.docker_image:
+//         name: superlists
+//         load_path: /tmp/superlists-img.tar
+//         source: load
+//         state: present
+//         force_source: true
+//       become: true
 
 
 Hooray!


### PR DESCRIPTION
Quick, fast chapter but I found a bug which I mentioned to Harry in a message. We had a discussion whether we should update chapter 11 or include the (short, one-line) solution here.

I'm personally on the opinion to extend the `ansible-playbook.yaml` here in chapter 17, when we notice the bug after running the FTs against the staging server. To me, it feels more natural not to include `force_source` in the "Import container image on server" task until we try to create a second deployment here, in chapter 17 where we notice that somehow the deployed version is old.
As Harry pointed out, some readers may try to deploy their code (therefore also face this bug) sooner. Still, I think we could include the solution in this chapter but mention it in a NOTE in chapter 11.