### PR TITLE
Csanád review chapter 18

### DIFF
--- a/chapter_18_second_deploy.asciidoc
+++ b/chapter_18_second_deploy.asciidoc
@@ -37,11 +37,11 @@ We start with the staging server:
 [role="against-server small-code"]
 [subs="specialcharacters,macros"]
 ----
-$ pass:quotes[*ansible-playbook --user=elspeth -i staging.ottg.co.uk, infra/deploy-playbook.yaml.yaml -vv*]
+$ pass:quotes[*ansible-playbook --user=elspeth -i staging.ottg.co.uk, infra/deploy-playbook.yaml -vv*]
 [...]
 
-PLAYBOOK: deploy-playbook.yaml.yaml ***********************************************
-1 plays in infra/deploy-playbook.yaml.yaml
+PLAYBOOK: deploy-playbook.yaml ***********************************************
+1 plays in infra/deploy-playbook.yaml
 
 PLAY [all] *********************************************************************
 
@@ -129,7 +129,7 @@ Assuming all is well, we then run our deploy against live:
 [role="against-server"]
 [subs="specialcharacters,macros"]
 ----
-$ pass:quotes[*ansible-playbook --user=elspeth -i www.ottg.co.uk, infra/deploy-playbook.yaml.yaml -vv*]
+$ pass:quotes[*ansible-playbook --user=elspeth -i www.ottg.co.uk, infra/deploy-playbook.yaml -vv*]
 ----
 
 


### PR DESCRIPTION
This chapter has been previously reviewed when it was `chapter 17`. I only found a small error: renaming the `ansible-playbook` to `deploy-playbook.yaml` resulted in `deploy-playbook.yaml.yaml`. I re-ran the deployment script just to be sure, but everything looked as expected.