### PR TITLE
Update HTML tutorial link to MDN in pre-requisite-installations.asciidoc

### DIFF
--- a/pre-requisite-installations.asciidoc
+++ b/pre-requisite-installations.asciidoc
@@ -64,7 +64,7 @@ Again, have a look at the three books I recommended previously if you're in any 
 ((("HTML", "tutorials")))I'm
 also assuming you have a basic grasp of how the web works--what HTML is,
 what a POST request is, and so on.  If you're not sure about those, you'll need to
-find a basic HTML tutorial; there are a few at http://www.webplatform.org/.  If
+find a basic HTML tutorial; there are a few at https://developer.mozilla.org/Learn_web_development.  If
 you can figure out how to create an HTML page on your PC and look at it in your
 browser, and understand what a form is and how it might work, then you're
 probably OK.


### PR DESCRIPTION
Removed link to webplatform.org (discontinued in 2015) and replaced with the new URL webplatform.org redirects to (MDN).

Might make it easy for newer developers to go straight to a free, reputable source