### PR TITLE
Csanád review of chapter 23

### DIFF
--- a/chapter_23_debugging_prod.asciidoc
+++ b/chapter_23_debugging_prod.asciidoc
@@ -359,13 +359,21 @@ class FunctionalTest(StaticLiveServerTestCase):
 And you can confirm that the FT will fail if you don't set `EMAIL_PASSWORD` in Docker.
 
 Now let's see if we can get our FTs to pass against the server:
+// CSANAD: I think this is missing from here:
+// [subs="specialcharacters,macros"]
+// ----
+// $ pass:quotes[*TEST_SERVER=localhost:8888 python src/manage.py test functional_tests.test_login*]
+// [...]
+//
+// OK
+// ----
 
 
 === Setting Secret Environment Variables on the Server
 
 ((("environment variables")))
 ((("secret values")))
-Just as in <<chapter_11_server_prep>>,
+Just as in <<chapter_12_ansible>>,
 the place we set environment variables on the server is in the _superlists.env_ file.
 
 Let's add it to the template first:
@@ -754,7 +762,7 @@ Perhaps a little ascii-art diagram will help:
 +----------------------------+
 ----
 
-===== Against Docker locally:
+===== Against Docker on the server:
 
 [role="skipme small-code"]
 ----
@@ -773,14 +781,15 @@ Perhaps a little ascii-art diagram will help:
 +----------------------------+
 ----
 
+// CSANAD: the chart looks broken in HTML, but looks perfect in the source code.
 
 
 .An Alternative For Managing Test Database Content: Talking Directly to the DB
 **********************************************************************
 An alternative way of managing database content inside Docker,
-or on a server, would be to talk directly to the DB
+or on a server, would be to talk directly to the DB.
 
-Since we're using SQLite, that involves writing to the file directly,
+Since we're using SQLite, that involves writing to the file directly.
 This can be fiddly to get right, because when we're running inside Django's
 test runner, Django takes over test database creation,
 so you end up having to write raw SQL and manage your connections to the database directly.
@@ -790,7 +799,7 @@ as well as needing to have the SECRET_KEY env var set to the same value as on th
 
 If we were using a "classic" database server like Postgres or MySQL,
 we'd be able to talk directly to the database over its port,
-and that's an approach I've used successfully in the past (see eg https://www.cosmicpython.com/book/chapter_02_repository.html#_inverting_the_dependency_orm_depends_on_model)
+and that's an approach I've used successfully in the past (see e.g. https://www.cosmicpython.com/book/chapter_02_repository.html#_inverting_the_dependency_orm_depends_on_model)
 but it's still fiddly to get right and usually requires writing your own SQL.
 **********************************************************************
 // CSANAD: maybe we should rephrase one of the occurrences of
@@ -842,7 +851,7 @@ And now against the server.  First, re-deploy to make sure our
 [role="against-server"]
 [subs="specialcharacters,quotes"]
 ----
-$ pass:quotes[*ansible-playbook --user=elspeth -i staging.ottg.co.uk, infra/deploy-playbook.yaml.yaml -vv*]
+$ pass:quotes[*ansible-playbook --user=elspeth -i staging.ottg.co.uk, infra/deploy-playbook.yaml -vv*]
 ----
 // CSANAD: at some point I deleted my .venv and reinstalled the pip packages on
 // my dedicated book-development environment. I just noticed I forgot about

--- a/chapter_23_debugging_prod.asciidoc
+++ b/chapter_23_debugging_prod.asciidoc
@@ -22,6 +22,9 @@ Let's see how that works against our staging server and Docker.
 
 === The Proof Is in the Pudding: Using Docker to Catch Final Bugs
 
+// CSANAD: we didn't make a commit after simplifying the tests with the `wait`
+// decorator.
+
 Remember the deployment checklist from <<chapter_18_second_deploy>>?
 Let's see if it can't come in useful today!
 
@@ -134,12 +137,16 @@ Traceback (most recent call last):
     raise SMTPSenderRefused(code, resp, from_addr)
 smtplib.SMTPSenderRefused: (530, b'5.7.0 Authentication Required. [...]
 ----
+// CSANAD: just a minor thing: these ^^^^ below the problematic lines render
+// much shorter in the html.
 
 That looks like a pretty good clue to what's going on.
 ((("", startref="Dockercatch21")))
 
 
 Sure enough!  Good to know our local Docker setup can repro the error on the server.
+// CSANAD: I think naming explicitly what the error on the server reproduced
+// by Docker is, would be clearer.
 
 
 === Another Environment Variable In Docker
@@ -325,7 +332,7 @@ Here's where we can put an early return in the FT:
 This test will still fail if you don't set `EMAIL_PASSWORD` to a valid value
 in Docker or on the server, so that's good enough for now.
 
-Here's how we populate the `.test_server` attribute:
+Here's how we populate the `FunctionalTest.test_server` attribute:
 
 
 [role="sourcecode"]
@@ -343,6 +350,8 @@ class FunctionalTest(StaticLiveServerTestCase):
 ====
 
 <1> We upgrade `test_server` to being an attribute on the test object,
+// CSANAD: "...on the FunctionalTest object," or "...on the FunctionalTest
+// instance (or "class")" would be a little more precise in my opinion.
     so we can access it in various places in our tests.
     We'll see this come in useful later too!
 
@@ -784,6 +793,8 @@ we'd be able to talk directly to the database over its port,
 and that's an approach I've used successfully in the past (see eg https://www.cosmicpython.com/book/chapter_02_repository.html#_inverting_the_dependency_orm_depends_on_model)
 but it's still fiddly to get right and usually requires writing your own SQL.
 **********************************************************************
+// CSANAD: maybe we should rephrase one of the occurrences of
+// "fiddly to get right" as they are used twice in the same note.
 
 
 === Testing the Management Command
@@ -826,13 +837,19 @@ OK
 
 
 And now against the server.  First, re-deploy to make sure our 
-
+// CSANAD: this sentence is incomplete.
 
 [role="against-server"]
 [subs="specialcharacters,quotes"]
 ----
 $ pass:quotes[*ansible-playbook --user=elspeth -i staging.ottg.co.uk, infra/deploy-playbook.yaml.yaml -vv*]
 ----
+// CSANAD: at some point I deleted my .venv and reinstalled the pip packages on
+// my dedicated book-development environment. I just noticed I forgot about
+// installing ansible. Just a thought, maybe we could mention in a footnote,
+// perhaps in chapter 11 (after installing ansible), that it's a common practice
+// to create a separate requirements-dev.txt and we could list selenium, ansible
+// and requests in ours.
 
 And now we run the test:
 
@@ -874,6 +891,14 @@ Hooray!
 
 
 === Test Database Cleanup
+
+// CSANAD: We should mention this Database Cleanup earlier in the chapter. I
+// think if the Reader needs this information, it is likely to be during the
+// chapter, not at the end of it.
+// I too had to re-run a test which got through the point of creating the user
+// and I faced this exact "UNIQUE constraint failed" error before I noticed the
+// chapter would deal with this possibility later.
+
 
 One more thing to be aware of: now that we're running against a real database,
 we don't get cleanup for free any more.

--- a/chapter_23_debugging_prod.asciidoc
+++ b/chapter_23_debugging_prod.asciidoc
@@ -328,6 +328,28 @@ Here's where we can put an early return in the FT:
     email = mail.outbox.pop()
 ----
 ====
+// CSANAD: This results in sending a real email to `edith@example.com` by
+// each run of `test_login.py`. I suggest moving this return way up:
+//
+// class LoginTest(FunctionalTest):
+//     def test_login_using_magic_link(self):
+//         if self.test_server:
+//             # Testing real email sending from the server is not worth it.
+//             return
+//
+//         # Edith goes to the awesome superlists site
+//         # and notices a "Log in" section in the navbar for the first time
+//         # It's telling her to enter her email address, so she does
+//         self.browser.get(self.live_server_url)
+//
+//         # CSANAD:
+//         # If we don't place the early return higher up, the following line will
+//         # cause a real email to be sent.
+//
+//         self.browser.find_element(By.CSS_SELECTOR, "input[name=email]").send_keys(
+//             TEST_EMAIL, Keys.ENTER
+//         )
+
 
 This test will still fail if you don't set `EMAIL_PASSWORD` to a valid value
 in Docker or on the server, so that's good enough for now.


### PR DESCRIPTION
The pace is, again, just right. Fast, not overly detailed but still easy to follow and answers pretty much all questions one may have. 

Later in the chapter, where we are deploying to the staging environment, I got stuck: `test_my_lists` failed by telling me it could not find `#id_logout`. Since the test ran fine just previously against the local docker, and the deployment is a `.tar` archive, and there may not be sqlite3 client installed by default, it may not be very straightforward to investigate if the reader believes there is a discrepancy between their local docker deployment and the staging.
This got me thinking: maybe we could add a few hints for what to do in case the reader believes there is a bug on staging: trying to reproduce it on the local docker environment and manually checking sqlite (e.g. by doing `SELECT * FROM account_token;` or `SELECT * FROM account_users;`...), add `logging.info()` or `logging.debug()` so that it shows up in the logs, etc). I think it would fit the scope of the chapter, as it's titled _Debugging And Testing Production Issues_.