### PR TITLE
Update all djangoproject.com links to 5.2

### DIFF
--- a/appendix_Django_Class-Based_Views.asciidoc
+++ b/appendix_Django_Class-Based_Views.asciidoc
@@ -71,7 +71,7 @@ def home_page(request):
 ====
 
 
-https://docs.djangoproject.com/en/1.11/ref/class-based-views/[Looking through
+https://docs.djangoproject.com/en/5.2/ref/class-based-views/[Looking through
 the options], Django has a generic view called `FormView`&mdash;let's see how
 that goes:
 

--- a/appendix_IV_testing_migrations.asciidoc
+++ b/appendix_IV_testing_migrations.asciidoc
@@ -120,7 +120,7 @@ sqlite3.IntegrityError: columns list_id, text are not unique
 Inserting a Data Migration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-https://docs.djangoproject.com/en/1.11/topics/migrations/#data-migrations[Data
+https://docs.djangoproject.com/en/5.2/topics/migrations/#data-migrations[Data
 migrations] are a special type of migration that modifies data in the database
 rather than changing the schema.  We need to create one that will run before
 we apply the integrity constraint, to preventively remove any duplicates.
@@ -135,7 +135,7 @@ Migrations for 'lists':
 $ pass:[<strong>mv lists/migrations/0005_*.py lists/migrations/0005_remove_duplicates.py</strong>]
 ----
 
-Check out https://docs.djangoproject.com/en/1.11/topics/migrations/#data-migrations[the
+Check out https://docs.djangoproject.com/en/5.2/topics/migrations/#data-migrations[the
 Django docs on data migrations] for more info, but here's how we add some
 instructions to change existing data:
 

--- a/chapter_05_post_and_database.asciidoc
+++ b/chapter_05_post_and_database.asciidoc
@@ -1045,7 +1045,7 @@ to check whether the right information was saved.
 ((("Django framework", "tutorials")))
 Django's ORM has many other helpful and intuitive features;
 this might be a good time to skim through the
-https://docs.djangoproject.com/en/5/intro/tutorial01/[Django tutorial],
+https://docs.djangoproject.com/en/5.2/intro/tutorial01/[Django tutorial],
 which has an excellent intro to them.
 
 NOTE: I've written this unit test in a very verbose style,

--- a/chapter_10_production_readiness.asciidoc
+++ b/chapter_10_production_readiness.asciidoc
@@ -197,7 +197,7 @@ First we install Whitenoise into our local environment:
 
 Then we tell Django to enable it, in _settings.py_footnote:[
 Find out more about Django Middleware
-in https://docs.djangoproject.com/en/5.1/topics/http/middleware/[the docs].
+in https://docs.djangoproject.com/en/5.2/topics/http/middleware/[the docs].
 ]:
 
 [role="sourcecode"]
@@ -484,7 +484,7 @@ _settings.py_ that we want to change for production:
 
 
 * `DEBUG` mode is all very well for hacking about on your own server,
-  but it https://docs.djangoproject.com/en/1.11/ref/settings/#debug[isn't secure].
+  but it https://docs.djangoproject.com/en/5.2/ref/settings/#debug[isn't secure].
   For example, exposing raw tracebacks to the world is a bad idea.
 
 * `SECRET_KEY` is used by Django for some of its crypto--things
@@ -1168,7 +1168,7 @@ so hopefully you have a toolset for how to do this sort of work.
 If you'd like to dig into this a little bit more,
 or if you're preparing a real project for release into the wild,
 The next step is to read up on Django's 
-https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/[Deployment Checklist].
+https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/[Deployment Checklist].
 
 The first suggestion is to use Django's "self-check" command,
 `manage.py check --deploy`.

--- a/chapter_12_ansible.asciidoc
+++ b/chapter_12_ansible.asciidoc
@@ -1396,7 +1396,7 @@ Here are some resources I used for inspiration,
 * The original https://12factor.net/[12-factor App] manifesto from the Heroku team
 
 * The official Django Docs'
-  https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/[Deployment Checklist]
+  https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/[Deployment Checklist]
 
 * https://hynek.me/talks/deploy-friendly/[How to Write Deployment-Friendly Apps] by Hynek Schlawack
 

--- a/part3.asciidoc
+++ b/part3.asciidoc
@@ -11,7 +11,7 @@ a core topic in web development.
 There's quite a lot of Django-specific content in this part,
 so if you weren't familiar with Django before starting on the book,
 you may find that taking a little time to run through the 
-https://docs.djangoproject.com/en/1.11/intro/tutorial01/#creating-models[official Django tutorial]
+https://docs.djangoproject.com/en/5.2/intro/tutorial01/#creating-models[official Django tutorial]
 will complement the next few chapters nicely.
 
 With that said, there are lots of good lessons about TDD in general in here too!


### PR DESCRIPTION
I came across an outdated link in Chapter 10 - Production Readiness. Then I figured I would grep for all djangoproject.com links that are _not_ 5.2 while I'm already at it. I tried, and all of them work.